### PR TITLE
emu6809: get the emulator to FAIL when the exit value is not zero.

### DIFF
--- a/backend-6809.c
+++ b/backend-6809.c
@@ -277,6 +277,11 @@ void gen_helpcall(struct node *n)
 
 void gen_helpclean(struct node *n)
 {
+        unsigned s;
+
+        s = get_size(n->right->type);
+	if (s)
+		printf("\tleas %d,s\n", s);
 }
 
 void gen_data_label(const char *name, unsigned align)

--- a/test/6809.c
+++ b/test/6809.c
@@ -51,8 +51,12 @@ unsigned imm_word (void)
 
 static void WRMEM (unsigned addr, unsigned data)
 {
-  /* Exit cleanly on writes to $FFFF */
-  if (addr == 0xFFFF) exit(0);
+  /* Exit on writes to $FFFF */
+  if (addr == 0xFFFF) {
+    if (data)
+      fprintf(stderr, "***FAIL %d\n", data);
+    exit(data);
+  }
 
   /* Write value to stdout when $FFFE */
   if (addr == 0xFFFE) {

--- a/test/emu6809.c
+++ b/test/emu6809.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
     }
 
     /* 0200-0xFDFF */
-    if (read(fd, &memory[0x200], 0xFC00) < 520) {
+    if (read(fd, &memory[0x200], 0xFC00) < 1) {
         fprintf(stderr, "emu6809: bad test.\n");
         perror(argv[1]);
         exit(1);


### PR DESCRIPTION
emu6809: get the emulator to FAIL when the exit value is not zero.
backend-6809.c: add code to `gen_helpclean()` to adjust the stack after a call to a helper function.