### PR TITLE
support6809: __bool and __not were the wrong way around.

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -236,7 +236,7 @@ static char *getopname(int op) {
 		case 0x0208: return("T_PERCENTEQ");
 		case 0x0209: return("T_LTEQ");
 		case 0x020A: return("T_GTEQ");
-		case 0x0200: return("T_UNI");
+		case 0x0200: return("T_PLUSEQ");
 		case '(': return("T_LPAREN");
 		case ')': return("T_RPAREN");
 		case '[': return("T_LSQUARE");
@@ -334,11 +334,14 @@ static void dump_tree(struct node *n, unsigned depth)
 		fputs("    ", stderr);
 	name= getopname(n->op);
 	if (name)
-		fprintf(stderr, "%s v%lx t%x f%x \n", name, n->value,
+		fprintf(stderr, "%s v%lx t%x f%x ", name, n->value,
 							 n->type, n->flags);
 	else
-		fprintf(stderr, "%04X v%lx t%x f%x \n", n->op, n->value,
+		fprintf(stderr, "%04X v%lx t%x f%x ", n->op, n->value,
 							n->type, n->flags);
+	if (n->snum)
+		fprintf(stderr, "\t%s", namestr(n->snum));
+	fputc('\n', stderr);
 	dump_tree(n->left, depth + 1);
 	dump_tree(n->right, depth + 1);
 }

--- a/support6809/makebool.s
+++ b/support6809/makebool.s
@@ -27,22 +27,22 @@
 ;	is appropriately set
 ;
 
-__boolc:
+__notc:
 	cmpb	#0
 	bra	booleq
-__bool:
-	subd	@zero
+__not:
+	cmpd	@zero
 booleq:
 	bne	ret0
 ret1:
 	ldd	@one
 	rts
 
-__notc:
+__boolc:
 	cmpb	#0
 	bra	boolne
-__not:
-	subd	@zero
+__bool:
+	cmpd	@zero
 boolne:
 	bne	ret1
 ret0:

--- a/test/testcrt0_6809.s
+++ b/test/testcrt0_6809.s
@@ -7,13 +7,14 @@
 
 hireg:	.word	0
 tmp:	.word	0
-zero:	.byte	0
+zero:	.word	0
 one:	.word	1
 
 	.code ; (at 0x0100)
 
 start:
-	clr	@zero
+	ldd	#0
+	std	@zero
 	ldd	#1
 	std	@one
 	jsr	_main


### PR DESCRIPTION
This fixes tests/0002-signed.c. We also need a word-sized @zero :-)