### PR TITLE
support6809/divide32x32.s: make tmp2 and tmp3 global

### DIFF
--- a/support6809/divide32x32.s
+++ b/support6809/divide32x32.s
@@ -27,6 +27,9 @@ DIVIS		.equ	0
 DIVID		.equ	6
 
 		.dp
+
+		.export tmp2
+		.export tmp3
 tmp2:		.word	0
 tmp3:		.word	0
 


### PR DESCRIPTION
This fixes the "missing symbol" errors on more of the tests.