### PR TITLE
support6809: add @zero and @one to the normal crt0.s

### DIFF
--- a/support6809/crt0.s
+++ b/support6809/crt0.s
@@ -1,6 +1,10 @@
 
 		.code
 start:
+		ldd	#0
+		std	@zero
+		ldd	#1
+		std	@one
 		jsr	_main
 		ldx	#0
 		stx	,--s

--- a/support6809/dp.s
+++ b/support6809/dp.s
@@ -2,8 +2,10 @@
 
 	.export hireg
 	.export tmp
+	.export zero
+	.export one
 
 hireg:	.word 0
 tmp:	.word 0
-zero:	.byte 0
+zero:	.word 0
 one:	.word 0


### PR DESCRIPTION
Given the library uses these, they need to be initialised in the normal crt0.s.