### PR TITLE
backend-6800: cmp_direct() needs to invalidate registers

### DIFF
--- a/backend-6800.c
+++ b/backend-6800.c
@@ -1769,12 +1769,14 @@ unsigned cmp_direct(struct node *n, const char *uop, const char *op)
 		printf("\tcmpb #%u\n", v);
 		printf("\tjsr %s\n", op);
 		n->flags |= ISBOOL;
+		invalidate_b();
 		return 1;
 	}
 	if (s == 2 && cpu_has_d) {
 		printf("\tsubd #%u\n", v);
 		printf("\tjsr %s\n", op);
 		n->flags |= ISBOOL;
+		invalidate_d();
 		return 1;
 	}
 	return 0;


### PR DESCRIPTION
The `cmp` or `sub` operations invalidate the B or D registers. We need to get the backend to re-load them, e.g.

```
  i=1;
  while (i <= 10) {
    printint(i);
    i= i + 1;
  }
```

Without the change, the code prints 1 1 1 1 1 1 1 1 1 1. With the change, the code prints 1 2 3 4 5 6 7 8 9 10.