### PR TITLE
backend-6800.c: Bring in the T_COMMA code from another backend.

### DIFF
--- a/backend-6800.c
+++ b/backend-6800.c
@@ -2303,6 +2303,16 @@ unsigned gen_shortcut(struct node *n)
 	if (unreachable)
 		return 1;
 	switch(n->op) {
+	case T_COMMA:
+		/* The comma operator discards the result of the left side,
+		   then evaluates the right. Avoid pushing/popping and
+		   generating stuff that is surplus */
+		l->flags |= NORETURN;
+		codegen_lr(l);
+		/* Parent determines child node requirements */
+		codegen_lr(r);
+		r->flags |= nr;
+		return 1;
 	case T_DEREF:
 	case T_DEREFPLUS:
 		/* Our right hand side is the thing to deref. See if we can


### PR DESCRIPTION
I borrowed from the z80 backend. This now works:
```
void cprintf(char *fmt, ...);

int x;
int y;

int main() {

  for (x=0, y=1; x < 6; x++, y=y+2) {
    cprintf("%d %d\n", x, y);
  }

  return(0);
}
```