### PR TITLE
backend-6800.c: fix 6809 code for function pointer calls.

### DIFF
--- a/backend-6800.c
+++ b/backend-6800.c
@@ -2852,7 +2852,7 @@ unsigned gen_node(struct node *n)
 		return do_stkeqop(n, "xminuseq");
 	/* Function calls that were not to a constant name */
 	case T_FUNCCALL:
-		if (cpu_has_xgdx) {
+		if (cpu_has_xgdx || cpu_is_09) {
 			make_x_d();
 			printf("\tjsr ,x\n");
 		} else {

--- a/test/wtests/input075.c
+++ b/test/wtests/input075.c
@@ -1,0 +1,13 @@
+void cprintf(char *fmt, ...);
+
+void fun(int a) 
+{ 
+    cprintf("Value of a is %d\n", a); 
+} 
+  
+int main() 
+{ 
+    void (*fun_ptr)(int) = &fun; 
+    (*fun_ptr)(10); 
+    return(0); 
+} 

--- a/test/wtests/out.input075.c
+++ b/test/wtests/out.input075.c
@@ -1,0 +1,1 @@
+Value of a is 10


### PR DESCRIPTION
Along with a wtest for function pointers.