### PR TITLE
backend-6800.c: fix bug in uniop8_on_s(), wrong stack offset

### DIFF
--- a/backend-6800.c
+++ b/backend-6800.c
@@ -1063,7 +1063,7 @@ unsigned uniop8_on_node(struct node *r, const char *op, unsigned off)
 	case T_LSTORE:
 	case T_LREF:
 		if (cpu_is_09)
-			uniop8_on_s(op, off + sp);
+			uniop8_on_s(op, v + off + sp);
 		else {
 			off = make_local_ptr(v + off, 255);
 			uniop8_on_ptr(op, off);


### PR DESCRIPTION
This fixes the `sign` initialisation bug in `_vfnprintf()` and now `printf()` works.