### PR TITLE
cc.c: Add a -V flag to print out the phases. Also, keep the symbol table file when -X is specified.

### DIFF
--- a/cc.c
+++ b/cc.c
@@ -43,7 +43,7 @@
  *	Split I/D
  */
 
-#undef DEBUG
+#define DEBUG
 
 #include <stdio.h>
 #include <stdint.h>
@@ -200,6 +200,7 @@ unsigned has_relocs;		/* Do we have relocations ? */
 
 const char *crtname = "crt0.o";
 
+int print_passes=0;
 int keep_temp;
 int last_phase = 4;
 int only_one_input;
@@ -445,7 +446,7 @@ static void run_command(void)
 	}
 	if (pid == 0) {
 #ifdef DEBUG
-		{
+		if (print_passes) {
 			const char **p = arglist;
 			printf("[");
 			while(*p)
@@ -496,7 +497,8 @@ static void redirect_in(const char *p)
 		fatal();
 	}
 #ifdef DEBUG
-	printf("<%s\n", p);
+	if (print_passes)
+		printf("<%s\n", p);
 #endif
 }
 
@@ -508,7 +510,8 @@ static void redirect_out(const char *p)
 		fatal();
 	}
 #ifdef DEBUG
-	printf(">%s\n", p);
+	if (print_passes)
+		printf(">%s\n", p);
 #endif
 }
 
@@ -952,6 +955,9 @@ int main(int argc, char *argv[]) {
 		case 's':	/* FIXME: for now - switch to getopt */
 			standalone = 1;
 			break;
+		case 'V':
+			print_passes = 1;
+			break;
 		case 'X':
 			uniopt(*p);
 			keep_temp = 1;
@@ -1007,6 +1013,7 @@ int main(int argc, char *argv[]) {
 	snprintf(symtab + 7, 6, "%x", getpid());
 	processing_loop();
 	unused_files();
-	unlink(symtab);
+	if (keep_temp==0)
+	  unlink(symtab);
 	return 0;
 }


### PR DESCRIPTION
This allows me (and others!) to run `gdb` on individual phases, e.g.

```
$ fcc -m6809 -S -O -V -X readdir.c
>readdir.%
[/opt/fcc//lib/cpp -I /opt/fcc//lib/6809/include -D __6809__ -E readdir.c ]
<readdir.%
>readdir.@
[/opt/fcc//lib/cc0 .symtmp299a ]
<readdir.@
>readdir.#
[/opt/fcc//lib/cc1.6800 ]
<readdir.#
>readdir.^
[/opt/fcc//lib/cc2.6800 .symtmp299a 6809 1 ]
<readdir.^
>readdir.s
[/opt/fcc//lib/copt /opt/fcc//lib/rules.6809 ]
```

Now I can do:

```
$ gdb cc2.6800
(gdb) run .symtmp299a 6809 1 <readdir.#
```