### PR TITLE
Fixed typo in _castf primitives on Z80 that lead to linker errors

### DIFF
--- a/supportz80/__cast2f.c
+++ b/supportz80/__cast2f.c
@@ -21,7 +21,7 @@ uint32_t _castul_f(unsigned long a1)
 }
 
 /* We could just use the uint32_t helper but 16bit is actually much simpler */
-uint32_t __castu_f(unsigned a1)
+uint32_t _castu_f(unsigned a1)
 {
     uint32_t r;
     int exp = 24 + EXCESS;
@@ -36,7 +36,7 @@ uint32_t __castu_f(unsigned a1)
     return PACK(0, exp, r);
 }
 
-uint32_t __castuc_f(unsigned char a1)
+uint32_t _castuc_f(unsigned char a1)
 {
     uint32_t r;
     int exp = 24 + EXCESS;
@@ -51,23 +51,23 @@ uint32_t __castuc_f(unsigned char a1)
     return PACK(0, exp, r);
 }
 
-uint32_t __castl_f(long a1)
+uint32_t _castl_f(long a1)
 {
     if (a1 < 0)
-        return _negatef(__castul_f(-a1));
-    return __castul_f(a1);
+        return _negatef(_castul_f(-a1));
+    return _castul_f(a1);
 }
 
-uint32_t __cast_f(int a1)
+uint32_t _cast_f(int a1)
 {
     if (a1 < 0)
-        return _negatef(__castu_f(-a1));
-    return __castu_f(a1);
+        return _negatef(_castu_f(-a1));
+    return _castu_f(a1);
 }
 
-uint32_t __castc_f(signed char a1)
+uint32_t _castc_f(signed char a1)
 {
     if (a1 < 0)
-        return _negatef(__castuc_f(-a1));
-    return __castuc_f(a1);
+        return _negatef(_castuc_f(-a1));
+    return _castuc_f(a1);
 }

--- a/supportz80/__castf.c
+++ b/supportz80/__castf.c
@@ -7,35 +7,35 @@ unsigned long _castf_ul(uint32_t a1)
     return 0;
 }
 
-unsigned __castf_u(uint32_t a1)
+unsigned _castf_u(uint32_t a1)
 {
     if (a1 & 0x7FFFFFFFUL)
         return MANT(a1) >> (EXP(a1) - EXCESS - 24);
     return 0;
 }
 
-unsigned char __castf_uc(uint32_t a1)
+unsigned char _castf_uc(uint32_t a1)
 {
     if (a1 & 0x7FFFFFFFUL)
         return MANT(a1) >> (EXP(a1) - EXCESS - 24);
     return 0;
 }
 
-long __castf_l(uint32_t a1)
+long _castf_l(uint32_t a1)
 {
     if (a1 == 0)
         return 0;
     if (a1 & 0x80000000)
-        return -__castf_ul(__negatef(a1));
-    return __castf_ul(a1);
+        return -_castf_ul(_negatef(a1));
+    return _castf_ul(a1);
 }
 
-int __castf_(uint32_t a1)
+int _castf_(uint32_t a1)
 {
-    return __castf_l(a1);
+    return _castf_l(a1);
 }
 
-signed char __castf_c(uint32_t a1)
+signed char _castf_c(uint32_t a1)
 {
-    return __castf_l(a1);
+    return _castf_l(a1);
 }


### PR DESCRIPTION
The software floating-point library used on Z80 contains multiple primitives with double underscore prefixes, like

long __castf_l(uint32_t a1);

This compiles to *three* underscores in the object file, when the compiler only expects two, leading to "unknown symbol" errors when casting floats. Easy fix.