### PR TITLE
__negatel.s: fixed carry bug when negating longs (Z80)

### DIFF
--- a/supportz80/__negatel.s
+++ b/supportz80/__negatel.s
@@ -12,7 +12,7 @@ __negatel:
 		ld	l,a
 		inc	hl
 		ld	a,h
-		or	a
+		or	l
 		push	hl
 		push	af
 		ld	hl,(__hireg)


### PR DESCRIPTION
This code previously checked for 16-bit carry by testing whether 'inc hl' left the high byte zero:

	ld	a,h
	or	a

...but this behaves incorrectly in cases like 0x00C0, where the high byte is zero because it started that way, not because it overflowed. The fix is to test whether both bytes are zero:

	ld	a,h
	or	l
