### PR TITLE
faster and smaller __switchl.s , 6800 emulator bug fix.

### DIFF
--- a/support6800/__switchl.s
+++ b/support6800/__switchl.s
@@ -26,8 +26,8 @@ __switchl:
 	inx
 	tstb
 	beq gotit
-	stx @tmp2
 next:
+	stx @tmp2
 	ldx 0,x
 	cpx @hireg
 	bne nomat
@@ -46,7 +46,6 @@ nomat:
 	inx
 	inx
 	inx
-	stx @tmp2
 	decb			; We know < 256 entries per switch
 	bne next
 gotit:

--- a/support6800/__switchl.s
+++ b/support6800/__switchl.s
@@ -1,40 +1,54 @@
+;
+;	ldx #_case
+;	jsr __switchl
+;
+; _case:
+;	.word number of case	; use only lower byte.
+;	.word case 1 high word
+;	.word case 1 low word
+;	.word jmp address 1
+;		:
+;	.word case N high word
+;	.word case N low word
+;	.word jmp address N
+;	.word default address
+;
+
 	.export __switchl
 
 __switchl:
 	; X holds the switch table, hireg:D the value
 	; Juggle as we are short of regs here - TODO find a nicer approach
-	staa @tmp
 	stab @tmp+1
+	staa @tmp
 	ldab 1,x
 	inx
 	inx
 	tstb
 	beq gotit
+	stx @tmp2
 next:
-	ldaa ,x
-	cmpa @hireg
+	ldx 0,x
+	cpx @hireg
 	bne nomat
-	ldaa 1,x
-	cmpa @hireg+1
+	ldx @tmp2
+	ldx 2,x
+	cpx @tmp
 	bne nomat
-	ldaa 2,x
-	cmpa @tmp
-	bne nomat
-	ldaa 3,x
-	cmpa @tmp+1
-	bne	nomat
-	ldx	4,x
-	jmp	,x
+	ldx @tmp2
+	ldx 4,x
+	jmp 0,x
 nomat:
+	ldx @tmp2
 	inx
 	inx
 	inx
 	inx
 	inx
 	inx
-moveon:
+	stx @tmp2
 	decb			; We know < 256 entries per switch
 	bne next
 gotit:
-	ldx ,x
-	jmp ,x
+	ldx 0,x
+	jmp 0,x

--- a/test/6800.c
+++ b/test/6800.c
@@ -1803,7 +1803,7 @@ static void m6800_cpx(struct m6800 *cpu, uint16_t a, uint16_t b)
     if (cpu->type == CPU_6800) {
         uint16_t r = (a & 0xFF00) - (b & 0xFF00);
         cpu->p &= ~(P_Z|P_N|P_V);
-        if (r == 0)
+        if (a == b)
             cpu->p |= P_Z;
         if (r & 0x8000)
             cpu->p |= P_N;


### PR DESCRIPTION
The program size has been reduced by performing switchl comparisons by word. It may generally be faster to compare starting with the lower word.

I found that this change caused a bug in the emulator.