### PR TITLE
a bit smaller and faster.

### DIFF
--- a/support6800/__castc.s
+++ b/support6800/__castc.s
@@ -4,8 +4,7 @@
 __castc_:
 __castc_u:
 	clra
-	bitb #$80
-	beq ispve
-	deca
-ispve:
+	asrb
+	rolb
+	sbca #$00
 	rts

--- a/support6800/__castc_l.s
+++ b/support6800/__castc_l.s
@@ -4,10 +4,9 @@
 __castc_l:
 __castc_ul:
 	clra
-	bitb #$80
-	beq ispve
-	deca
-ispve:
+	asrb
+	rolb
+	sbca #$00
 	sta @hireg
 	sta @hireg+1
 	rts

--- a/support6800/__xdiveqc.s
+++ b/support6800/__xdiveqc.s
@@ -19,7 +19,7 @@ __xremeqc:
 	bsr sex
 	bsr absd
 	staa @tmp
-	stab @tmp1+1
+	stab @tmp+1
 	ldab ,x
 	bsr sex
 	bita #0x80


### PR DESCRIPTION
For testing, I used a modified version of 0008-promotion.c

```
int func(signed char a)
{
    return a;
}

int lfunc(signed char a)
{
    return a;
}

int main(int argc, char *argv[])
{
    signed char a;
    signed int b;
    signed long c;

    a = 0xA5;
    b = a;
    if ((unsigned)b != 0xFFA5)
        return 1;

    b = 0x1234;
    a = b;
    if (a != 0x34)
        return 2;

    a = 0xAB;
    if ((unsigned)func(a) != 0xFFAB)
        return 3;
    a = 0x20;
    if ((unsigned)func(a) != 0x0020)
        return 4;

    a = 0xA5;
    c = a;
    if ((unsigned long)c != 0xFFFFFFA5)
       return 11;

    b = 0x1234;
    a = b;
    if (a != 0x34)
        return 12;

    a = 0xAB;
    if ((unsigned long)lfunc(a) != 0xFFFFFFAB)
        return 13;

    a = 0x20;
    if ((unsigned long)lfunc(a) != 0x00000020)
        return 14;

    return 0;
}

```