### PR TITLE
6800: add missing helper files.  __loadnl.s __pluseqf.c

### DIFF
--- a/support6800/__loadnl.s
+++ b/support6800/__loadnl.s
@@ -1,0 +1,26 @@
+;
+;        jsr __loadnl
+;        .word address
+;
+	.export __loadnl
+	.code
+__loadnl:
+	stx @tmp	; X where we can manipulate it
+	tsx
+	ldx 0,x		; return address
+	stx @tmp2	; save return address
+	tsx		; get sp again
+	ldab @tmp2+1	; calculate new return address
+	addb #2
+	stab 1,x	; restore new return address
+	ldab @tmp2
+	adcb #0
+	stab 0,x
+	ldx @tmp2	; get word address again
+	clrb
+	stab @hireg+1
+	stab @hireg
+	ldab 1,x
+	ldaa 0,x
+	ldx @tmp
+	rts

--- a/support6800/__pluseqf.c
+++ b/support6800/__pluseqf.c
@@ -1,0 +1,30 @@
+#include "libfp.h"
+
+//
+//	*TOS += high:d
+//
+uint32_t _pluseqf(float a2, float *a1)
+{
+	return (*a1 = *a1 + a2);
+}
+//
+//	*TOS -= high:d
+//
+uint32_t _minuseqf(float a2, float *a1)
+{
+	return (*a1 = *a1 - a2);
+}
+//
+//	*TOS *= high:d
+//
+uint32_t _muleqf(float a2, float *a1)
+{
+	return (*a1 = *a1 * a2);
+}
+//
+//	*TOS /= high:d
+//
+uint32_t _diveqf(float a2, float *a1)
+{
+	return (*a1 = *a1 / a2);
+}


### PR DESCRIPTION
test program.

```
//
//      helper test program
//              loadn*,loadl*,loada*
//
//      On the 6800, only loadnl seems to be generated.
//      The others loadn*, loadl* and loada* are not generated.
//

unsigned char a[1000];

int     main(int argc, char **argv)
{
        unsigned long   xl,yl;

        xl = (unsigned long)&a[999];    // loadnl
        yl = (unsigned long)&a;
        if (xl != yl + 999)
                return 1;

        return 0;
}
```

```
int main(void) {
    float e, a;

    a = 1.0;
    e = -60000.0;

    a += e;
    if (a != -59999.0)
	    return 1;
    a -= e;
    if (a != 1.0 )
	    return 2;
    a *= e;
    if (a != -60000.0 )
	    return 3;
    a /= e;
    if (a != 1.0 )
	    return 4;

    return 0;
}
```