### PR TITLE
8070: Fix "&" operator

### DIFF
--- a/backend-8070.c
+++ b/backend-8070.c
@@ -1356,7 +1356,7 @@ unsigned gen_direct(struct node *n)
 				}
 			}
 			if ((v & 0xFF) == 0x00)
-				set_a(0);
+				load_ea(1, 0x00);
 			else if ((v & 0xFF) != 0xFF) {
 				printf("\tand a,=%u\n", v);
 				invalidate_a();


### PR DESCRIPTION
The following code returns 0x34.

```
int main() {
	int a = 0x1234;
	return a & 0x8000;
}
```

This PR fixes it.
